### PR TITLE
Publish plugins to s3://get.pulumi.com, too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
+    - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
     - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -19,7 +19,7 @@ if [ "$(go env GOOS)" = "windows" ]; then
     BIN_SUFFIX=".exe"
 fi
 
-(cd provider &&  go build \
+(cd provider && go build \
    -ldflags "-X github.com/pulumi/pulumi-${PROVIDER_NAME}/provider/v2/pkg/version.Version=${VERSION}" \
    -o "${WORK_PATH}/pulumi-resource-${PROVIDER_NAME}${BIN_SUFFIX}" \
    "${ROOT}/cmd/pulumi-resource-${PROVIDER_NAME}")
@@ -27,20 +27,62 @@ fi
 # Tar up the plugin
 tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .
 
-# rel.pulumi.com is in our production account, so assume that role first
-CREDS_JSON=$(aws sts assume-role \
-                 --role-arn "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
-                 --role-session-name "upload-plugin-pulumi-resource-aws" \
-                 --external-id "upload-pulumi-release")
+# Assume the provided role using the session name and (optional) external ID.
+# Uses the "default" credentials, ignoring AWS_PROFILE if set.
+# Usage: assume_iam_role <role-arn> <session-name> [external-id]
+function assume_iam_role() {
+    local ROLE_ARN=${1}
+    local SESSION_NAME=${2}
+    local EXTERNAL_ID=${3}
 
-# Use the credentials we just assumed
-export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
-export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
-export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
+    echo "Assuming IAM Role '${ROLE_ARN}"
+    echo "    Session    : ${SESSION_NAME}"
+    echo "    External ID: ${EXTERNAL_ID}"
 
-echo "Uploading ${PLUGIN_PACKAGE_NAME}..."
+    local CREDS_JSON="{}"
+    if [ -z ${EXTERNAL_ID} ]; then
+        CREDS_JSON=$(aws sts assume-role \
+                 --profile "default" \
+                 --role-arn "${ROLE_ARN}" \
+                 --role-session-name "${SESSION_NAME}" )
+    else
+        CREDS_JSON=$(aws sts assume-role \
+                 --profile "default" \
+                 --role-arn "${ROLE_ARN}" \
+                 --role-session-name "${SESSION_NAME}" \
+                 --external-id "${EXTERNAL_ID}" )
+    fi
 
+    export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
+    export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
+    export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
+}
+
+# Clear the environment variables set after calling assume_iam_role to get back to
+# the initial state. (Using the "default" profile.)
+function unassume_iam_role() {
+    unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
+}
+
+echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://rel.pulumi.com..."
+assume_iam_role \
+     "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
+     "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
+     "upload-pulumi-release"
 aws s3 cp --only-show-errors "${PLUGIN_PACKAGE_PATH}" "s3://rel.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
+unassume_iam_role
+
+# Assume the role to publish plugins to s3://get.pulumi.com. We upload the plugins to two buckets while
+# we transition to only publishing/serving them from get.pulumi.com.
+echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
+assume_iam_role \
+     "arn:aws:iam::058607598222:role/PulumiUploadRelease" \
+     "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
+     "upload-pulumi-release"
+aws s3 cp \
+    --only-show-errors --acl public-read \
+    "${PLUGIN_PACKAGE_PATH}" "s3://get.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
+unassume_iam_role
 
 rm -rf "${PLUGIN_PACKAGE_DIR}"
 rm -rf "${WORK_PATH}"


### PR DESCRIPTION
This PR updates the publish-plugin.sh script to copy built plugins to s3://get.pulumi.com
in addition to s3://rel.pulumi.com. This is so that we can migrate to serving plugins via
CDN on https://get.pulumi.com, instead of https://api.pulumi.com like we do today.

For more information about the overall effort, see [this comment](https://github.com/pulumi/pulumi-service/issues/3068#issuecomment-626878731).

In addition, immediately before this code gets merged, I will also update the AWS access key
used for this repo on:

- Travis CI: https://travis-ci.com/github/pulumi/pulumi-mailgun/settings
- GitHub Actions: https://github.com/pulumi/pulumi-mailgun/settings/secrets (if applicable)

The access key will be fore a different IAM User. This is part of https://github.com/pulumi/home/issues/708,
and managing Pulumi's internal AWS access using Pulumi (and migrating off hand-crafted IAM permissions we
set up in 2017).

> I'm assuming that this repository doesn't need to create AWS resources, so
> I'll use an access key that only has permissions to upload resources and
> publish plugins but nothing else. I'll discover if this is correct when
> testing out the release path post-merge. (And can update Travis out of band.)

## Next Steps

After this review gets the LGTM, the next steps are:

1. Update the AWS credentials on Travis, GitHub
2. Merge the PR. Wait for master to be green. Fix any problems associated with this PR.
3. Celebrate I didn't break anything.
